### PR TITLE
Percent encoding username and password on Uri Display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,7 @@ dependencies = [
  "bytes",
  "md-5",
  "nom",
+ "percent-encoding",
  "quote",
  "rand",
  "rsip-derives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ md-5 = "0.9.1"
 sha2 = "0.9.5"
 testing-utils = { version = "0.1.1", optional = true }
 bstr = "0.2.17"
+percent-encoding = "2.3.0"
 
 [features]
 test-utils = ["testing-utils"]

--- a/tests/common/uri/mod.rs
+++ b/tests/common/uri/mod.rs
@@ -12,6 +12,36 @@ mod display {
     use super::*;
 
     #[test]
+    fn special_characters() {
+        assert_eq!(
+            Uri {
+                scheme: None,
+                auth: Some(("user@localhost", Option::<String>::None).into()),
+                host_with_port: ("server2.com", Option::<u16>::None).into(),
+                params: Default::default(),
+                headers: Default::default()
+            }
+            .to_string(),
+            String::from("user%40localhost@server2.com")
+        );
+    }
+
+    #[test]
+    fn special_characters_with_pass() {
+        assert_eq!(
+            Uri {
+                scheme: None,
+                auth: Some(("user@localhost", Some("pass word")).into()),
+                host_with_port: ("server2.com", Option::<u16>::None).into(),
+                params: Default::default(),
+                headers: Default::default()
+            }
+            .to_string(),
+            String::from("user%40localhost:pass%20word@server2.com")
+        );
+    }
+
+    #[test]
     fn display1() {
         assert_eq!(
             Uri {
@@ -92,6 +122,34 @@ mod display {
 
 mod parser {
     use super::*;
+
+    #[test]
+    fn parser_special_characters() {
+        assert_eq!(
+            Tokenizer {
+                scheme: None,
+                auth: Some(
+                    (
+                        "user%40localhost".as_bytes(),
+                        Some("pass%20word".as_bytes())
+                    )
+                        .into()
+                ),
+                host_with_port: ("server2.com".as_bytes(), None).into(),
+                params: vec![],
+                headers: None,
+                ..Default::default()
+            }
+            .try_into(),
+            Ok(Uri {
+                scheme: None,
+                auth: Some(("user@localhost", Some("pass word")).into()),
+                host_with_port: ("server2.com", Option::<u16>::None).into(),
+                params: Default::default(),
+                headers: Default::default()
+            })
+        )
+    }
 
     #[test]
     fn parser1() {


### PR DESCRIPTION
Per RFC-3261 BNF, user and password portions of a SIP uri must be "escaped".